### PR TITLE
Bump Node Version to 14

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14
 
       - name: Install Dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # NWCalvank.dev
 
-My developer blog, using the Gatsby Starter Blog template and taking
-inspiration from Dan Abramov's [overreacted](https://overreacted.io/).
+My developer blog with almost no content. And crappy styling.
 
 ## Prerequisites
 
-- Node.js LTS (just don't use v13 and you should be fine)
+- Node.js LTS
 
 ## Getting Started
 


### PR DESCRIPTION
This is the minimum version required by latest Gatsby, apparently.

And it's also what I happened to be running when I tested my dependency upgrade locally, so we'll stick with that for the moment.