### PR TITLE
Fix Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - master
@@ -13,14 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/iron
-
-      - name: Install Dependencies
-        run: npm ci
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -31,4 +24,4 @@ jobs:
       - name: Deploy
         run: |
           aws s3 sync ./content/blog s3://nwcalvank.dev --delete &&\
-          aws cloudfront create-invalidation --distribution-id EL17OVML2MU5Z
+          aws cloudfront create-invalidation --distribution-id EL17OVML2MU5Z --paths "/*"

--- a/.github/workflows/invalidate.yml
+++ b/.github/workflows/invalidate.yml
@@ -1,15 +1,11 @@
-name: Deploy
+name: Invalidate CDN
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - master
 
 jobs:
-  shipit:
-    name: Shipit
+  invalidate:
+    name: Invalidate CloudFront Distribution
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,6 +17,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      - name: Deploy
+      - name: Invalidate CloudFront Distribution
         run: |
-          aws s3 sync ./content/blog s3://nwcalvank.dev --delete
+          aws cloudfront create-invalidation --distribution-id EL17OVML2MU5Z --paths "/*"


### PR DESCRIPTION
Fixes the CloudFront invalidation command, but also moves it to a separate workflow, as I don't care if it serves cached content for a while.

And, if I do care, I can just run the invalidation workflow or do it manually.