### PR TITLE
Basic Light/Dark Mode via OS Preference Setting

### DIFF
--- a/content/blog/a-few-of-my-favourite-algorithms/index.html
+++ b/content/blog/a-few-of-my-favourite-algorithms/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/a-few-of-my-favourite-algorithms/index.md
+++ b/content/blog/a-few-of-my-favourite-algorithms/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # A Few of My Favourite Algorithms
 
 **August 23rd, 2020**

--- a/content/blog/async-functions-are-overrated/index.html
+++ b/content/blog/async-functions-are-overrated/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/async-functions-are-overrated/index.md
+++ b/content/blog/async-functions-are-overrated/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # JavaScript's async Functions are Overrated
 
 **September 13th, 2020**

--- a/content/blog/filter/index.html
+++ b/content/blog/filter/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/filter/index.md
+++ b/content/blog/filter/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Complete Guide to filter
 
 **June 17th, 2020**

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -11,6 +11,17 @@
       width: 80%;
       max-width: 1200px;
     }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
+    }
   </style>
 </head>
 <body>

--- a/content/blog/index.md
+++ b/content/blog/index.md
@@ -1,19 +1,19 @@
-# nwcalvank.dev
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
 
-## Latest Podcast Episode
+  @media (prefers-color-scheme: dark) {
+    h1, h2 {
+      color: #fff;
+    }
 
-<div style="margin: 1rem 2rem">
-    <iframe
-      style="border-radius: 12px"
-      src="https://open.spotify.com/embed/show/5Z0Nuyrg1QeGYfTQLnWDSq?utm_source=generator&theme=0"
-      width="100%"
-      height="152"
-      frameborder="0"
-      allowfullscreen=""
-      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-      loading="lazy"
-    ></iframe>
-</div>
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
+# NWCalvank.dev
 
 ## Complete Guides
 

--- a/content/blog/javascripts-optional-chaining-is-a-code-smell/index.html
+++ b/content/blog/javascripts-optional-chaining-is-a-code-smell/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/javascripts-optional-chaining-is-a-code-smell/index.md
+++ b/content/blog/javascripts-optional-chaining-is-a-code-smell/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # JavaScript's Optional Chaining is a Code Smell
 
 **August 4th, 2020**

--- a/content/blog/map/index.md
+++ b/content/blog/map/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Complete Guide to map
 
 **June 10th, 2020**

--- a/content/blog/pass-by-value-vs-reference/index.html
+++ b/content/blog/pass-by-value-vs-reference/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/pass-by-value-vs-reference/index.md
+++ b/content/blog/pass-by-value-vs-reference/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Pass by Value vs Reference
 
 **September 2nd, 2020**

--- a/content/blog/preview.js
+++ b/content/blog/preview.js
@@ -33,46 +33,46 @@ template.innerHTML = `
 `;
 
 class Preview extends HTMLElement {
-    static get observedAttributes() {
-        return ["date", "link", "title"];
-    }
+  static get observedAttributes() {
+    return ["date", "link", "title"];
+  }
 
-    constructor() {
-        super();
-        this.attachShadow({ mode: "open" });
-        this.shadowRoot.appendChild(template.content.cloneNode(true));
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-        this.date = this.shadowRoot.getElementById("date");
-        this.link = this.shadowRoot.getElementById("link");
-        this.title = this.shadowRoot.getElementById("title");
-    }
+    this.date = this.shadowRoot.getElementById("date");
+    this.link = this.shadowRoot.getElementById("link");
+    this.title = this.shadowRoot.getElementById("title");
+  }
 
-    attributeChangedCallback(attr, oldVal, newVal) {
-        if (oldVal === newVal) return;
-        switch (attr) {
-            case "date":
-                this.date.innerHTML = newVal;
-                break;
-            case "link":
-                this.link.href = newVal;
-                break;
-            case "title":
-                this.title.innerHTML = newVal;
-                break;
-        }
+  attributeChangedCallback(attr, oldVal, newVal) {
+    if (oldVal === newVal) return;
+    switch (attr) {
+      case "date":
+        this.date.innerHTML = newVal;
+        break;
+      case "link":
+        this.link.href = newVal;
+        break;
+      case "title":
+        this.title.innerHTML = newVal;
+        break;
     }
+  }
 
-    connectedCallback() {
-        if (!this.getAttribute("date")) {
-            this.setAttribute("date", "Just Now");
-        }
-        if (!this.getAttribute("link")) {
-            this.setAttribute("link", "not-found");
-        }
-        if (!this.getAttribute("title")) {
-            this.setAttribute("title", "Hello World");
-        }
+  connectedCallback() {
+    if (!this.getAttribute("date")) {
+      this.setAttribute("date", "Just Now");
     }
+    if (!this.getAttribute("link")) {
+      this.setAttribute("link", "not-found");
+    }
+    if (!this.getAttribute("title")) {
+      this.setAttribute("title", "Hello World");
+    }
+  }
 }
 
 window.customElements.define("blog-post-preview", Preview);

--- a/content/blog/preview.js
+++ b/content/blog/preview.js
@@ -23,18 +23,18 @@ template.innerHTML = `
     }
 </style>
 
-<a id="link" class="link">
-    <div class="card">
+<article>
+    <a id="link" class="link card">
         <h2 class="title"><slot name="title">MISSING TITLE</slot></h2>
         <p id="date" class="date"></p>
         <p class="description"><slot name="description">MISSING DESCRIPTION</slot></p>
-    </div>
-</a>
+    </a>
+</article>
 `;
 
 class Preview extends HTMLElement {
     static get observedAttributes() {
-        return [ "date", "link", "title"];
+        return ["date", "link", "title"];
     }
 
     constructor() {
@@ -45,7 +45,7 @@ class Preview extends HTMLElement {
         this.date = this.shadowRoot.getElementById("date");
         this.link = this.shadowRoot.getElementById("link");
         this.title = this.shadowRoot.getElementById("title");
-    } 
+    }
 
     attributeChangedCallback(attr, oldVal, newVal) {
         if (oldVal === newVal) return;
@@ -63,7 +63,7 @@ class Preview extends HTMLElement {
     }
 
     connectedCallback() {
-    if (!this.getAttribute("date")) {
+        if (!this.getAttribute("date")) {
             this.setAttribute("date", "Just Now");
         }
         if (!this.getAttribute("link")) {

--- a/content/blog/programming-is-not-a-shortcut-to-wealth/index.html
+++ b/content/blog/programming-is-not-a-shortcut-to-wealth/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/programming-is-not-a-shortcut-to-wealth/index.md
+++ b/content/blog/programming-is-not-a-shortcut-to-wealth/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Programming is not a Shortcut to Wealth
 
 **October 25th, 2020**

--- a/content/blog/recursion/index.html
+++ b/content/blog/recursion/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/recursion/index.md
+++ b/content/blog/recursion/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Complete Guide to Recursion
 
 **July 24th, 2020**

--- a/content/blog/reduce/index.html
+++ b/content/blog/reduce/index.html
@@ -3,12 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
       width: 80%;
       max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/reduce/index.md
+++ b/content/blog/reduce/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Complete Guide to reduce
 
 **June 26th, 2020**

--- a/content/blog/transducers/index.html
+++ b/content/blog/transducers/index.html
@@ -3,11 +3,23 @@
     type="module"
     src="https://cdn.jsdelivr.net/gh/zerodevx/zero-md@2/dist/zero-md.min.js"
   ></script>
-  <style>
+  <style> 
     .content-container {
       margin: auto;
       margin-top: 60px;
-      max-width: 80%;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1e1e1e;
+        color: #fff;
+      }
+
+      .markdown-body {
+        color-scheme: dark;
+      }
     }
   </style>
 </head>

--- a/content/blog/transducers/index.md
+++ b/content/blog/transducers/index.md
@@ -1,3 +1,18 @@
+<style>
+  .markdown-body h1 {
+    border-bottom: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    h1, h2, p, li {
+      color: #fff;
+    }
+
+    .markdown-body {
+      color-scheme: dark;
+    }
+</style>
+
 # Complete Guide to Transducers
 
 **July 1st, 2020**

--- a/content/templates/index.html
+++ b/content/templates/index.html
@@ -25,6 +25,6 @@
 </head>
 <body>
   <div class="content-container">
-    <zero-md src="/map/index.md"></zero-md>
+    <zero-md src="/PARENT_DIRECTORY/index.md"></zero-md>
   </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "serve": "14.2.1"
   },
   "scripts": {
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "new": "",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json}\"",
     "start": "serve"
   }
 }


### PR DESCRIPTION
This uses CSS' `prefers-color-scheme` to read any colour scheme preference set on the user's machine, defaulting to light theme (for now, anyway).

I'm intending to do automatic styling via a `templates/{index.html|index.md}` file and a little npm script, but at this point, I figured I'd just :shipit: 

This is basically a WIP, but I want dark mode deployed.